### PR TITLE
Fix errors in tensorflow model conversion to ONNX

### DIFF
--- a/nebullvm/api/frontend/tf.py
+++ b/nebullvm/api/frontend/tf.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Tuple, Union
 
@@ -57,7 +58,7 @@ def optimize_tf_model(
     model_optimizer = MultiCompilerOptimizer(n_jobs=-1)
     with TemporaryDirectory() as tmp_dir:
         onnx_path = model_converter.convert(
-            model, model_params.input_sizes, tmp_dir
+            model, model_params.input_sizes, Path(tmp_dir)
         )
         model_optimized = model_optimizer.optimize(
             str(onnx_path), dl_library, model_params

--- a/nebullvm/converters/converters.py
+++ b/nebullvm/converters/converters.py
@@ -66,7 +66,6 @@ class ONNXConverter(BaseConverter):
         elif isinstance(model, tf.Module):
             convert_tf_to_onnx(
                 model=model,
-                input_sizes=input_sizes,
                 output_file_path=save_path / onnx_name,
             )
             return save_path / onnx_name

--- a/nebullvm/optimizers/base.py
+++ b/nebullvm/optimizers/base.py
@@ -1,8 +1,23 @@
 from abc import abstractmethod, ABC
 from logging import Logger
 
+import onnx
+
 from nebullvm.base import DeepLearningFramework, ModelParams
 from nebullvm.inference_learners.base import BaseInferenceLearner
+
+
+def get_input_names(onnx_model: str):
+    model = onnx.load(onnx_model)
+
+    input_all = [node.name for node in model.graph.input]
+    return input_all
+
+
+def get_output_names(onnx_model: str):
+    model = onnx.load(onnx_model)
+    output_all = [node.name for node in model.graph.output]
+    return output_all
 
 
 class BaseOptimizer(ABC):

--- a/nebullvm/optimizers/multi_compiler.py
+++ b/nebullvm/optimizers/multi_compiler.py
@@ -49,10 +49,14 @@ def _optimize_with_compiler(
         model_optimized = optimizer.optimize(**kwargs)
         latency = metric_func(model_optimized)
     except Exception as ex:
-        warnings.warn(
+        warning_msg = (
             f"Compilation failed with {compiler.value}. Got error {ex}."
             f"The compiler will be skipped."
         )
+        if logger is None:
+            warnings.warn(warning_msg)
+        else:
+            logger.warning(warning_msg)
         latency = np.inf
         model_optimized = None
     return model_optimized, latency

--- a/nebullvm/optimizers/tensor_rt.py
+++ b/nebullvm/optimizers/tensor_rt.py
@@ -8,7 +8,11 @@ from nebullvm.inference_learners.tensor_rt import (
     NVIDIA_INFERENCE_LEARNERS,
     NvidiaInferenceLearner,
 )
-from nebullvm.optimizers.base import BaseOptimizer
+from nebullvm.optimizers.base import (
+    BaseOptimizer,
+    get_input_names,
+    get_output_names,
+)
 
 if torch.cuda.is_available():
     try:
@@ -94,11 +98,7 @@ class TensorRTOptimizer(BaseOptimizer):
         model = NVIDIA_INFERENCE_LEARNERS[output_library].from_engine_path(
             network_parameters=model_params,
             engine_path=engine_path,
-            input_names=[
-                f"input_{i}" for i in range(len(model_params.input_sizes))
-            ],
-            output_names=[
-                f"output_{i}" for i in range(len(model_params.output_sizes))
-            ],
+            input_names=get_input_names(onnx_model),
+            output_names=get_output_names(onnx_model),
         )
         return model


### PR DESCRIPTION
Fix error in TF to ONNX format due to mismatch between input names of tensorflow and nebullvm generated onnx model.