### PR TITLE
fix install encoding issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIREMENTS = [
 ]
 
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
+long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="nebullvm",


### PR DESCRIPTION
When installing from source on Windows 11 in a conda environment, I experienced an encoding issue because the readme contains emoji but I suppose due to my python version (python 3.9.10 h9a09f29_2_cpython conda-forge) it uses cp1252 and complains about the encoding. This PR just explicitly sets the encoding to utf-8.

```
> pip install .
Processing c:\users\webma\onedrive - aarhus universitet\au - 2022\cognitive neuroscience\nebullvm
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\<redacted>\nebullvm\setup.py", line 14, in <module>   
          long_description = (this_directory / "README.md").read_text()
        File "C:\tools\miniconda3\envs\eegtorch\lib\pathlib.py", line 1267, in read_text
          return f.read()
        File "C:\tools\miniconda3\envs\eegtorch\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 2025: character maps to <undefined>
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```