### PR TITLE
Fix missing config.cmake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     version="0.2.1",
     packages=find_packages(),
     install_requires=REQUIREMENTS,
+    include_package_data=True,
     package_data={
         # Include all bash files:
         "": ["*.sh"],


### PR DESCRIPTION
The wheel file on Pypi is missing `config.cmake` files and also `tvm_installers` folder. This fix should include those files in the wheel (verified with `python setup.py bdist_wheel`).