### PR TITLE
select compiler with hyperparameter

### DIFF
--- a/nebullvm/pipelines/steps.py
+++ b/nebullvm/pipelines/steps.py
@@ -43,6 +43,7 @@ from nebullvm.utils.compilers import (
     bladedisc_is_available,
     torch_tensorrt_is_available,
 )
+from nebullvm.utils.compilers import selector as compiler_selector
 from nebullvm.utils.data import DataManager
 from nebullvm.utils.feedback_collector import FEEDBACK_COLLECTOR
 
@@ -379,29 +380,34 @@ class TorchOptimizerStep(OptimizerStep):
                 logger=self._logger
             ),
         }
+        compilers = compiler_selector()
         if (
-            tvm_is_available()
+            (compilers is None or ModelCompiler.APACHE_TVM.value in compilers)
+            and tvm_is_available()
             and ModelCompiler.APACHE_TVM not in ignore_compilers
         ):
             optimizers[ModelCompiler.APACHE_TVM] = ApacheTVMOptimizer(
                 logger=self._logger
             )
         if (
-            deepsparse_is_available()
+            (compilers is None or ModelCompiler.DEEPSPARSE.value in compilers)
+            and deepsparse_is_available()
             and ModelCompiler.DEEPSPARSE not in ignore_compilers
         ):
             optimizers[ModelCompiler.DEEPSPARSE] = DeepSparseOptimizer(
                 logger=self._logger
             )
         if (
-            bladedisc_is_available()
+            (compilers is None or ModelCompiler.BLADEDISC.value in compilers)
+            and bladedisc_is_available()
             and ModelCompiler.BLADEDISC not in ignore_compilers
         ):
             optimizers[ModelCompiler.BLADEDISC] = BladeDISCOptimizer(
                 logger=self._logger
             )
         if (
-            torch_tensorrt_is_available()
+            (compilers is None or ModelCompiler.TENSOR_RT.value in compilers)
+            and torch_tensorrt_is_available()
             and ModelCompiler.TENSOR_RT not in ignore_compilers
         ):
             optimizers[ModelCompiler.TENSOR_RT] = TensorRTOptimizer(

--- a/nebullvm/utils/compilers.py
+++ b/nebullvm/utils/compilers.py
@@ -1,7 +1,10 @@
+from typing import List
 import cpuinfo
 import torch
 
 from nebullvm.base import ModelCompiler
+
+from hyperparameter import auto_param
 
 
 def tvm_is_available() -> bool:
@@ -40,7 +43,14 @@ def deepsparse_is_available() -> bool:
         return True
 
 
+@auto_param("nebullvm.compilers")
+def selector(enabled: List[str] = None):
+    return enabled
+
+
 def select_compilers_from_hardware_onnx():
+    if selector() is not None:
+        return [x for x in ModelCompiler if x.value in selector()]
     compilers = [ModelCompiler.ONNX_RUNTIME]
     if tvm_is_available():
         compilers.append(ModelCompiler.APACHE_TVM)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ tensorflow>=2.7.0
 tf2onnx>=1.8.4
 torch>=1.10.0, <=1.12
 tqdm>=4.63.0
+hyperparameter
 transformers
 pytest

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ REQUIREMENTS = [
     "tf2onnx>=1.8.4",
     "torch>=1.10.0, <=1.12",
     "tqdm>=4.63.0",
+    "hyperparameter",
 ]
 
 


### PR DESCRIPTION
Signed-off-by: reiase <reiase@gmail.com>

example for selecting compiler with hyperparameter:
```python
from hyperparameter import param_scope
with param_scope() as ps:
    ps.nebullvm.compilers.selector.enabled = ["onnxruntime"]
    optimized_model = optimize_model(
        model, input_data=input_data, optimization_time="constrained")
```

`nebullvm.compilers.selector.enabled` is the key for config compiler. We can also select compilers with a dict-style configuration:

```python
with param_scope(**{"nebullvm.compilers.selector.enabled": ["onnxruntime"]}) as ps:
    optimized_model = optimize_model(
        model, input_data=input_data, optimization_time="constrained")
```

Advantages for managing configuration with hyperparameter :
1. keeping the API simple for normal users;
2. expose more detailed parameters to advanced users;