### PR TITLE
Scaffold app runtime

### DIFF
--- a/nebullvm/core/app.py
+++ b/nebullvm/core/app.py
@@ -1,0 +1,68 @@
+from enum import Enum
+from queue import Empty
+from typing import Dict, Any, Iterator
+
+from deepdiff import DeepDiff
+
+from nebullvm.core.operations import Operation
+from nebullvm.utils.logger import get_logger
+
+log = get_logger()
+
+
+class AppPhase(str, Enum):
+    RUNNING = "running"
+    STOPPED = "stopped"
+    STARTING = "starting"
+    ERROR = "error"
+
+
+class App:
+    def __init__(self, root_op: Operation):
+        self.root_op = root_op
+        self.phase = AppPhase.STARTING
+        self._last_state: Dict[str, Any] = {}
+
+    @property
+    def state(self):
+        return {
+            "phase": self.phase,
+            **self.root_op.state,
+        }
+
+    def stop(self):
+        log.info("App is stopping...")
+        self.root_op.stop()
+        self.phase = AppPhase.STOPPED
+        log.info("App stopped")
+
+    def run(self):
+        self.phase = AppPhase.RUNNING
+        while self.phase is AppPhase.RUNNING:
+            self._run_once()
+
+    def visit_tree(self) -> Iterator[Operation]:
+        return self.root_op.visit_tree()
+
+    def _state_has_changed(self) -> bool:
+        diff = DeepDiff(self._last_state, self.state)
+        return len(diff) > 0
+
+    def _check_errors(self):
+        try:
+            err = self.root_op.error_queue.get(timeout_seconds=0)
+            self._err = err
+            self.stop()
+        except Empty:
+            pass
+
+    def _run_once(self):
+        # Check if there's any error
+        self._check_errors()
+        # Avoid running the root operation if the state hasn't changed.
+        if self._state_has_changed() is False:
+            return
+        # Run the root operation
+        log.debug("state change detected, running execute")
+        self._last_state = self.state
+        self.root_op.execute()

--- a/nebullvm/core/hosts.py
+++ b/nebullvm/core/hosts.py
@@ -1,0 +1,18 @@
+import abc
+
+from nebullvm.core.queues import QueueFactory, QueueKind
+
+
+class Host(abc.ABC):
+    def __init__(self, queue_factory: QueueFactory):
+        self.queue_factory = queue_factory
+
+
+class LocalHost(Host):
+    def __init__(self):
+        super().__init__(QueueFactory(kind=QueueKind.MULTIPROCESSING))
+
+
+class RemoteHost(Host):
+    def __init__(self):
+        super().__init__(QueueFactory(kind=QueueKind.HTTP))

--- a/nebullvm/core/operations.py
+++ b/nebullvm/core/operations.py
@@ -1,0 +1,124 @@
+import abc
+from functools import partial
+from typing import Dict, Any, List, Optional, Iterator
+
+from nebullvm.core import util
+from nebullvm.core.hosts import Host
+from nebullvm.core.queues import ErrorQueue, ExecuteQueue, DeltaQueue
+from nebullvm.utils.logger import get_logger
+
+log = get_logger()
+
+
+def _update_op_name(op: "Operation", name: str, parent: "Operation"):
+    op.name = f"{parent.name}.{name}"
+
+
+class Operation(abc.ABC):
+    def __init__(self, block: bool = False, host: Optional[Host] = None):
+        self.__name = ""
+        self.__error_queue: Optional[ErrorQueue] = None
+        self.__execute_queue: Optional[ExecuteQueue] = None
+        self.__delta_queue: Optional[DeltaQueue] = None
+        self._state_vars = set()
+        self._children_operations = set()
+        self._setattr_fun = self._default_setattr
+        self._on_stop_callbacks: List[callable] = []
+        self.block = block
+        self.host = host
+
+    @staticmethod
+    def __is_state_var(key, value) -> bool:
+        def is_proxy() -> bool:
+            from nebullvm.core import proxies
+            if isinstance(value, proxies.DeltaSetattrProxy):
+                return True
+            if isinstance(value, proxies.AsyncExecuteProxy):
+                return True
+            if isinstance(value, partial):
+                return value.func.__name__ == "_async_execute"
+            return False
+
+        if key.startswith('_'):
+            return False
+        if is_proxy():
+            return False
+        if isinstance(value, Host) or key == "host":
+            return False
+
+        return util.is_json_serializable(value)
+
+    def _default_setattr(self, key, value):
+        if isinstance(value, Operation):
+            self._children_operations.add(key)
+            _update_op_name(value, key, self)
+        if self.__is_state_var(key, value):
+            self._state_vars.add(key)
+        super().__setattr__(key, value)
+
+    def __setattr__(self, key, value):
+        fun = getattr(self, "_setattr_fun", self._default_setattr)
+        fun(key, value)
+
+    @property
+    def state(self) -> Dict[str, Any]:
+        return {
+            "vars": {var: getattr(self, var) for var in self._state_vars},
+            "operations": {op: getattr(self, op).state for op in self._children_operations}
+        }
+
+    @property
+    def name(self) -> str:
+        return self.__name or "root"
+
+    @name.setter
+    def name(self, value: str):
+        self.__name = value
+
+    def set_state(self, state: Dict[str, Any]):
+        for var, value in state["vars"].items():
+            setattr(self, var, value)
+        for op, op_state in state["operations"].items():
+            getattr(self, op).set_state(op_state)
+
+    @property
+    def children_operations(self) -> List["Operation"]:
+        return [getattr(self, k) for k in self._children_operations]
+
+    def stop(self):
+        # Stop children
+        for op in self.children_operations:
+            op.stop()
+        # Run callbacks and stop workers
+        for c in self._on_stop_callbacks:
+            c()
+
+    def on_stop(self, callback: callable):
+        self._on_stop_callbacks.append(callback)
+
+    def visit_tree(self) -> Iterator["Operation"]:
+        yield self
+        for op in self.children_operations:
+            yield from op.visit_tree()
+
+    @abc.abstractmethod
+    def execute(self, *args, **kwargs):
+        pass
+
+    @property
+    def error_queue(self) -> ErrorQueue:
+        if self.__error_queue is None:
+            self.__error_queue = self.host.queue_factory.new_error_queue()
+        return self.__error_queue
+
+    @property
+    def delta_queue(self) -> DeltaQueue:
+        if self.__delta_queue is None:
+            self.__delta_queue = self.host.queue_factory.new_delta_queue()
+        return self.__delta_queue
+
+    @property
+    def execute_queue(self) -> ExecuteQueue:
+        if self.__execute_queue is None:
+            self.__execute_queue = self.host.queue_factory.new_execute_queue()
+        return self.__execute_queue

--- a/nebullvm/core/proxies.py
+++ b/nebullvm/core/proxies.py
@@ -1,0 +1,47 @@
+from copy import deepcopy
+
+from deepdiff import Delta, DeepDiff
+
+from nebullvm.core.operations import Operation
+from nebullvm.core.queues import ExecuteRequest, DeltaQueue, OperationDelta, ExecuteQueue
+
+
+class AsyncExecuteProxy:
+    """AsyncExecuteProxy is meant for replacing the execute method Operations to make it async.
+    Instead of executing the operation directly, the proxy puts an execute request on the execute queue, which is
+    consumed by a runner on a different thread/process.
+    """
+
+    def __init__(self, op: Operation, queue: ExecuteQueue):
+        self.op = op
+        self.queue = queue
+
+    def __call__(self, *args, **kwargs):
+        req = ExecuteRequest(
+            args=args,
+            kwargs=kwargs,
+            state=self.op.state,
+        )
+        self.queue.put(req)
+
+
+class DeltaSetattrProxy:
+    """DeltaSetattrProxy replaces the __setattr__ method of the contained operation so that it can capture the state
+    deltas and send them to the delta queue.
+    """
+
+    def __init__(self, op: Operation, delta_queue: DeltaQueue):
+        self._delta_queue = delta_queue
+        self._op = op
+
+    def __call__(self, name: str, value: any):
+        original_state = deepcopy(self._op.state)
+        self._op._default_setattr(name, value) # noqa
+        diff = DeepDiff(original_state, self._op.state)
+        op_delta = OperationDelta(
+            delta=Delta(diff),
+            op=self._op.name,
+        )
+        # if delta is not empty then put into queue
+        if len(op_delta) > 0:
+            self._delta_queue.put(op_delta)

--- a/nebullvm/core/queues.py
+++ b/nebullvm/core/queues.py
@@ -1,0 +1,179 @@
+import enum
+import multiprocessing
+from dataclasses import dataclass, field
+from queue import Empty
+from threading import Thread
+from time import time
+from typing import Any, Optional, Dict, Protocol, Tuple, Generic, Union, TypeVar, List
+
+from deepdiff import Delta
+
+from nebullvm.utils.logger import get_logger
+
+log = get_logger()
+
+
+class Queue(Protocol):
+    def put(self, item: Any) -> None:
+        pass
+
+    def get(self, timeout_seconds: Optional[float] = None) -> Any:
+        pass
+
+
+class SingleProcessQueue:
+    def put(self, item: Any) -> None:
+        pass
+
+    def get(self, timeout_seconds: Optional[float] = None) -> Any:
+        pass
+
+
+class HttpQueue:
+    def put(self, item: Any) -> None:
+        pass
+
+    def get(self, timeout_seconds: Optional[float] = None) -> Any:
+        pass
+
+
+class MultiprocessingQueue:
+    def __init__(self):
+        self._queue = multiprocessing.Queue()
+
+    def get(self, timeout_seconds: Optional[float] = None) -> Any:
+        return self._queue.get(timeout=timeout_seconds)
+
+    def put(self, item: Any) -> None:
+        self._queue.put(item)
+
+
+@dataclass
+class ExecuteRequest:
+    args: Tuple[any] = field(default_factory=tuple)
+    kwargs: Dict[str, any] = field(default_factory=dict)
+    state: Dict[str, any] = field(default_factory=dict)
+
+
+@dataclass
+class OperationDelta:
+    op: str
+    delta: Delta
+
+    def __len__(self):
+        return self.delta.to_dict().__len__()
+
+
+class ExecuteQueue:
+    def __init__(self, queue: Queue):
+        self._queue = queue
+
+    def get(self, timeout_seconds: Optional[float] = None) -> ExecuteRequest:
+        return self._queue.get(timeout_seconds=timeout_seconds)
+
+    def put(self, item: ExecuteRequest) -> None:
+        self._queue.put(item)
+
+
+class ErrorQueue:
+    def __init__(self, queue: Queue):
+        self._queue = queue
+
+    def get(self, timeout_seconds: Optional[float] = None) -> Exception:
+        return self._queue.get(timeout_seconds=timeout_seconds)
+
+    def put(self, item: Exception) -> None:
+        self._queue.put(item)
+
+
+class DeltaQueue:
+    def __init__(self, queue: Queue):
+        self._queue = queue
+
+    def get(self, timeout_seconds: Optional[float] = None) -> OperationDelta:
+        return self._queue.get(timeout_seconds=timeout_seconds)
+
+    def put(self, item: OperationDelta) -> None:
+        self._queue.put(item)
+
+
+class QueueKind(enum.Enum):
+    MULTIPROCESSING = "multiprocessing"
+    SINGLE_PROCESS = "single-process"
+    HTTP = "http"
+
+
+class QueueFactory:
+    def __init__(self, kind: QueueKind):
+        self.kind = kind
+
+    def _new_queue(self) -> Queue:
+        if self.kind is QueueKind.MULTIPROCESSING:
+            return MultiprocessingQueue()
+        if self.kind is QueueKind.HTTP:
+            return HttpQueue()
+        return SingleProcessQueue()
+
+    def new_error_queue(self) -> ErrorQueue:
+        return ErrorQueue(self._new_queue())
+
+    def new_execute_queue(self) -> ExecuteQueue:
+        return ExecuteQueue(self._new_queue())
+
+    def new_delta_queue(self) -> DeltaQueue:
+        return DeltaQueue(self._new_queue())
+
+
+_T = TypeVar("_T", bound=Union[OperationDelta, ExecuteRequest, Exception])
+
+
+class QueueCollector(Generic[_T]):
+    """
+    QueueCollector is a helper class that collects batches of items from a provided queue.
+    """
+
+    def __init__(self, source: Queue, collect_interval_seconds: float = 0.1):
+        self.source = source
+        self.collect_interval_seconds = collect_interval_seconds
+
+    def collect(self) -> List[_T]:
+        start = time()
+        items = []
+        while time() - start < self.collect_interval_seconds:
+            try:
+                delta = self.source.get(timeout_seconds=self.collect_interval_seconds)
+                items.append(delta)
+            except Empty:
+                pass
+        return items
+
+
+class QueueSyncer(Thread):
+    """
+    QueueSyncer is a helper class that synchronizes two queues, by collecting items form a source and
+    putting them into a sink.
+    """
+
+    def __init__(self, source: QueueCollector, sink: Queue):
+        """
+        Parameters
+        ----------
+        source: QueueCollector
+            The collector that fetches items from the source queue.
+        sink: Queue
+            The queue to put the items into.
+        """
+        super().__init__(daemon=True)
+        self.source = source
+        self.sink = sink
+
+    def run(self) -> None:
+        while True:
+            items = self.source.collect()
+            for i in items:
+                self.sink.put(i)
+
+    def stop(self) -> None:
+        log.debug("Stopping queue syncer")
+        self.join(0)
+        log.debug("Queue syncer stopped")

--- a/nebullvm/core/runtimes.py
+++ b/nebullvm/core/runtimes.py
@@ -1,0 +1,318 @@
+import abc
+import contextlib
+import sys
+import threading
+from collections import defaultdict
+from dataclasses import dataclass, field
+from functools import partial
+from multiprocessing import Process
+from threading import Thread
+from typing import List, Type, Dict, Callable
+from typing import Optional
+
+from deepdiff import Delta
+
+from nebullvm.core import util
+from nebullvm.core.app import App, AppPhase
+from nebullvm.core.hosts import RemoteHost, LocalHost
+from nebullvm.core.operations import Operation
+from nebullvm.core.proxies import AsyncExecuteProxy
+from nebullvm.core.proxies import DeltaSetattrProxy
+from nebullvm.core.queues import ExecuteQueue, ErrorQueue, DeltaQueue, OperationDelta, QueueCollector, QueueSyncer
+from nebullvm.utils.logger import get_logger
+
+log = get_logger()
+
+
+@contextlib.contextmanager
+def _state_deltas_generation(op: Operation, delta_queue: DeltaQueue):
+    """Context manager for collecting operation state deltas and sending them to a delta queue."""
+    proxy = DeltaSetattrProxy(op, delta_queue)
+    with util.patched_attr(op, "_setattr_fun", proxy):
+        yield
+
+
+class _DeltaApplier(threading.Thread):
+    """
+    DeltaApplier is a daemon that collects state deltas from a source DeltaQueue and applies them to the operation
+    state.
+
+    Optionally, it can send any state update delta generated when modifying the operation state with the deltas
+    received from the collector to an upstream DeltaQueue.
+    """
+
+    def __init__(self, op: Operation, collector: QueueCollector[OperationDelta], upstream: Optional[DeltaQueue] = None):
+        """
+        Parameters
+        ----------
+        op: Operation
+            The operation to apply deltas to.
+        collector: QueueCollector
+            Collector that gives deltas to apply to the operation state.
+        upstream: Optional[DeltaQueue]
+            Optional delta queue to which send any state update delta generated when modifying the operation state
+            with the deltas received from the collector.
+        """
+        super().__init__(daemon=True)
+        self._op = op
+        self._collector = collector
+        self._upstream_queue = upstream
+
+    def _get_op(self, name: str) -> Optional[Operation]:
+        for op in self._op.visit_tree():
+            if op.name == name:
+                return op
+        return None
+
+    @staticmethod
+    def _group_by_op(op_deltas: List[OperationDelta]) -> Dict[str, List[Delta]]:
+        grouped = defaultdict(list)
+        for op_delta in op_deltas:
+            grouped[op_delta.op].append(op_delta.delta)
+        return grouped
+
+    def apply_op_deltas(self, op: Operation, deltas: List[Delta]):
+        state = op.state
+        for delta in deltas:
+            state += delta
+        if self._upstream_queue is not None:
+            with _state_deltas_generation(op, self._upstream_queue):
+                op.set_state(state)
+        else:
+            op.set_state(state)
+
+    def _apply_deltas(self, deltas: List[OperationDelta]):
+        log.debug(f"Applying {len(deltas)} deltas [op {self._op.name}]")
+        for op_name, deltas in self._group_by_op(deltas).items():
+            op = self._get_op(op_name)
+            if op is None:
+                log.error(f'Could not find operation "{op_name}" for delta [op {self._op.name}]')
+                continue
+            self.apply_op_deltas(op, deltas)
+
+    def _run_once(self):
+        deltas = self._collector.collect()
+        if len(deltas) > 0:
+            self._apply_deltas(deltas)
+
+    def run(self, *args, **kwargs):
+        log.debug(f"Starting delta applier [op {self._op.name}]")
+        while True:
+            self._run_once()
+
+    def stop(self):
+        self.join(0)
+
+
+@dataclass
+class AsyncRunner(abc.ABC):
+    """Runner for executing operations asynchronously.
+
+    The runner wraps the Operation execute method into an event loop that consumes an ExecuteQueue,
+    and runs the "execute" function of the operation everytime there's a new execute request in the queue.
+
+    If the Operation has children operation that need to be run asynchronously, the runner wraps their
+    execute function during the setup of the event loop, so that they will be managed by an AsycnRunner too.
+    """
+    op: Operation
+    execute_fn: callable
+    execute_queue: ExecuteQueue
+    delta_queue: DeltaQueue
+    error_queue: ErrorQueue
+
+    def _run_loop(self):
+        self._setup()
+        while True:
+            try:
+                self._run_once()
+            except KeyboardInterrupt:
+                pass
+            except Exception as e:
+                log.exception(e)
+                self.error_queue.put(e)
+
+    def _setup(self):
+        for child in self.op.children_operations:
+            wrap_execute_fn(
+                op=child,
+                execute_fn=child.execute,
+                upstream_delta_queue=self.delta_queue,
+                upstream_error_queue=self.error_queue,
+            )
+
+    def _run_once(self):
+        # Wait for next execute request
+        req = self.execute_queue.get()
+        log.debug(f"Got execute request [op {self.op.name}]: {req}")
+
+        # Temporarily replace __setattr__ method so that we can capture the state deltas
+        # and send them to the delta queue
+        with _state_deltas_generation(self.op, self.delta_queue):
+            # Inject state
+            self.op.set_state(req.state)
+            # Execute the operation
+            self.execute_fn(*req.args, **req.kwargs)
+
+    @abc.abstractmethod
+    def start(self):
+        pass
+
+    @abc.abstractmethod
+    def stop(self):
+        pass
+
+
+class MultiThreadRunner(AsyncRunner):
+    _thread: Optional[Thread] = field(default=None, init=False)
+
+    def start(self):
+        self._thread = Thread(target=self._run_loop, name=self.op.name, daemon=False)
+        log.debug(f'Starting runner thread "{self._thread.name}" [op {self.op.name}]')
+        self._thread.start()
+
+    def stop(self):
+        log.debug(f'Stopping runner thread "{self._thread.name}" [op {self.op.name}]')
+        self._thread.join(0)
+        log.debug(f'Runner thread stopped "{self._thread.name}" [op {self.op.name}]')
+
+
+class MultiProcessRunner(AsyncRunner):
+    _process: Optional[Process] = field(default=None, init=False)
+
+    def start(self):
+        self._process = Process(target=self._run_loop, name=self.op.name, daemon=False)
+        log.debug(f'Starting runner process "{self._process.name}" [op {self.op.name}]')
+        self._process.start()
+
+    def stop(self):
+        log.debug(f'Stopping runner process "{self._process.name}", [op {self.op.name}]')
+        self._process.terminate()
+        log.debug(f'Runner process stopped "{self._process.name}" [op {self.op.name}]')
+
+
+def _async_execute(
+        *args,
+        op: Operation,
+        execute_fn: Callable,
+        upstream_delta_queue: Optional[DeltaQueue] = None,
+        upstream_error_queue: Optional[ErrorQueue] = None,
+        **kwargs,
+):
+    # Restore original execute function
+    op.execute = execute_fn
+    # If we are already in a sub-process,
+    # then sync the error queue with the upstream one
+    if upstream_error_queue is not None:
+        error_collector = QueueCollector(op.error_queue)
+        error_syncer = QueueSyncer(error_collector, upstream_error_queue)
+        error_syncer.start()
+    # Start async runner
+    runner_cls: Type[AsyncRunner]
+    if isinstance(op.host, RemoteHost):
+        runner_cls = MultiThreadRunner
+    else:
+        runner_cls = MultiProcessRunner
+    runner = runner_cls(
+        op,
+        execute_fn=execute_fn,
+        execute_queue=op.execute_queue,
+        delta_queue=op.delta_queue,
+        error_queue=op.error_queue,
+    )
+    runner.start()
+    op.on_stop(runner.stop)
+    # Start DeltaApplier for syncing state deltas
+    collector = QueueCollector(op.delta_queue)
+    applier = _DeltaApplier(op=op, collector=collector, upstream=upstream_delta_queue)
+    applier.start()
+    op.on_stop(applier.stop)
+    # Replace execute function with async proxy
+    op.execute = AsyncExecuteProxy(op, op.execute_queue)
+    # Run execute
+    op.execute(*args, **kwargs)
+
+
+def _wrap_children_execute(
+        *args,
+        op: Operation,
+        execute_fn: callable,
+        upstream_delta_queue: Optional[DeltaQueue] = None,
+        upstream_error_queue: Optional[ErrorQueue] = None,
+        **kwargs,
+):
+    for child in op.children_operations:
+        child_execute_fn = child.execute
+        if child.block is False:
+            child.execute = partial(
+                _async_execute,
+                op=child,
+                execute_fn=child_execute_fn,
+                upstream_delta_queue=upstream_delta_queue,
+                upstream_error_queue=upstream_error_queue,
+            )
+        else:
+            child.execute = partial(
+                _wrap_children_execute,
+                op=child,
+                execute_fn=child_execute_fn,
+                upstream_delta_queue=upstream_delta_queue,
+                upstream_error_queue=upstream_error_queue,
+            )
+    op.execute = execute_fn
+    op.execute(*args, **kwargs)
+
+
+def wrap_execute_fn(
+        *,
+        op: Operation,
+        execute_fn: callable,
+        upstream_delta_queue: Optional[DeltaQueue] = None,
+        upstream_error_queue: Optional[ErrorQueue] = None,
+):
+    """Wrap the execute function of the provided operation and its children to support async execution.
+
+    In case of async execution, the wrapping of the execute function of the operation children is done at
+    runtime when the execute function of the parent operation is called, so that the resulting process gets managed
+    by the process of the parent operation.
+    """
+    if op.block is False:
+        new_execute_fn = partial(
+            _async_execute,
+            op=op,
+            execute_fn=execute_fn,
+            upstream_delta_queue=upstream_delta_queue,
+            upstream_error_queue=upstream_error_queue,
+        )
+    else:
+        new_execute_fn = partial(
+            _wrap_children_execute,
+            op=op,
+            execute_fn=execute_fn,
+            upstream_delta_queue=upstream_delta_queue,
+            upstream_error_queue=upstream_error_queue,
+        )
+    op.execute = new_execute_fn
+
+
+class AppRuntime:
+    def __init__(self, app: App):
+        self.app = app
+        self.default_backend = LocalHost()
+
+    def _attach_default_backend(self):
+        for op in self.app.visit_tree():
+            if op.host is None:
+                op.host = self.default_backend
+
+    def _setup(self):
+        self._attach_default_backend()
+        wrap_execute_fn(op=self.app.root_op, execute_fn=self.app.root_op.execute)
+
+    def run(self):
+        try:
+            self._setup()
+            self.app.run()
+        except KeyboardInterrupt:
+            self.app.stop()
+        if self.app.phase is AppPhase.ERROR:
+            sys.exit(1)

--- a/nebullvm/core/util.py
+++ b/nebullvm/core/util.py
@@ -1,0 +1,22 @@
+import json
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def patched_attr(obj: object, attr_name: str, new_attr: any):
+    old_method = getattr(obj, attr_name)
+    setattr(obj, attr_name, new_attr)
+    yield
+    setattr(obj, attr_name, old_method)
+
+
+def is_json_serializable(obj: Any) -> bool:
+    primitive_types = (int, float, str, bool, type(None))
+    if type(obj) in primitive_types:
+        return True
+    try:
+        json.dumps(obj)
+        return True
+    except TypeError:
+        return False

--- a/nebullvm/utils/logger.py
+++ b/nebullvm/utils/logger.py
@@ -3,25 +3,33 @@ import os
 import warnings
 from copy import copy
 
+LOGGER_NAME = "nebullvm_logger"
+
 
 def debug_mode_enabled():
     return int(os.environ.get("DEBUG_MODE", "0")) > 0
 
 
 def setup_logger():
+    level = logging.DEBUG
     if not debug_mode_enabled():
         warnings.filterwarnings("ignore")
+        level = logging.INFO
 
-    logger = logging.getLogger("nebullvm_logger")
-    logger.setLevel(logging.INFO)
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.setLevel(level)
 
     ch = logging.StreamHandler()
     formatter = logging.Formatter(
-        "%(asctime)s [ %(levelname)s ] %(message)s", "%d/%m/%Y %I:%M:%S %p"
+        "%(asctime)s | %(processName)s %(threadName)s [ %(levelname)s ] %(message)s", "%d/%m/%Y %I:%M:%S %p"
     )
     ch.setFormatter(formatter)
     logger.handlers = [ch]
     logger.propagate = False
+
+
+def get_logger() -> logging.Logger:
+    return logging.getLogger(LOGGER_NAME)
 
 
 def save_root_logger_state():


### PR DESCRIPTION
The PR scaffolds the app runtime, contained in the `core` package. 

A few notes:
* we can't manage the async execution on a separate method that then calls the `execute` method implemented by the users, since the user's implementation can call directly the `execute` of children operations. The adopted solution thus replaces the `execute` method with a new function that handles async execution when required
* we need to handle stop signal propagation properly through queues (since we are on multiple processes on multiple machines we cannot just use callback functions)
* we need to implement some caching mechanism on the execute requests for preventing flooding the execution queues