### PR TITLE
Update README.md patch 1 by adding multiple device option- CPU and GPU

### DIFF
--- a/apps/accelerate/forward_forward/README.md
+++ b/apps/accelerate/forward_forward/README.md
@@ -31,6 +31,10 @@ At the current stage, this implementation supports the main architectures discus
 
 ```python
 from forward_forward import train_with_forward_forward_algorithm
+import os
+import torch
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
 
 
 trained_model = train_with_forward_forward_algorithm(
@@ -38,7 +42,7 @@ trained_model = train_with_forward_forward_algorithm(
     n_layers=3,
     hidden_size=2000,
     lr=0.03,
-    device="cuda",
+    device=device,
     epochs=100,
     batch_size=5000,
     theta=2.,

--- a/apps/accelerate/forward_forward/README.md
+++ b/apps/accelerate/forward_forward/README.md
@@ -36,7 +36,6 @@ import torch
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-
 trained_model = train_with_forward_forward_algorithm(
     model_type="progressive",
     n_layers=3,


### PR DESCRIPTION
Having encountered errors when trying to implement the code provided on ReadME.md on my MacOS M1 VSCode version1.74.3 and Python 3.8 , I decided to add an option so that in case the VSCode does not have GPU available, it may switch to CPU without causing any troubles. Hence, I updated the ReadME.md file by adding the following lines of code in the USAGE section,:
```
import os
import torch

device = "cuda" if torch.cuda.is_available() else "cpu"
```

and setting `device=device` instead of `device="CUDA"` in `trained_model=` part.