### PR TITLE
Fixed version compatibility error when importing speedster

### DIFF
--- a/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
+++ b/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
@@ -73,7 +73,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install speedster"
+        "!pip install speedste"
       ]
     },
     {

--- a/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
+++ b/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
@@ -73,7 +73,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install speedste"
+        "!pip install speedster"
       ]
     },
     {

--- a/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
+++ b/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
@@ -99,13 +99,13 @@
     {
       "cell_type": "code",
       "source": [
-        "# This cell will fix version compatibility errors\n",
+        "# This cell fixes version compatibility errors\n",
         "!pip install virtualenv\n",
         "!virtualenv -p python3 newenv\n",
         "!pip install protobuf==3.12.2 speedster onnx==1.8.0"
       ],
       "metadata": {
-        "id": "l4gJ7VLVnTld"
+        "id": "1UFT4ekVcWR4"
       },
       "execution_count": null,
       "outputs": []
@@ -158,7 +158,7 @@
       },
       "outputs": [],
       "source": [
-        "# If you encountered any error, relaunch the cell\n",
+        "# If you encountered any error, run the cell again\n",
         "import tensorflow as tf\n",
         "from tensorflow.keras.applications.resnet50 import ResNet50\n",
         "from speedster import optimize_model\n",
@@ -273,21 +273,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "dkt67_Orwlv4",
-        "outputId": "2115dc49-9fe0-4e2c-c200-20868c6f50e8"
+        "id": "dkt67_Orwlv4"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Average latency original model: 0.0524 seconds\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "num_iters = 100\n",
         "\n",
@@ -317,21 +305,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "4PodpaDVfwzT",
-        "outputId": "805344a8-90eb-4818-8363-d79012c02dd1"
+        "id": "4PodpaDVfwzT"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Average latency optimized model: 0.0071 seconds\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Warmup\n",
         "for i in range(10):\n",
@@ -406,21 +382,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "0MMrL3959hli",
-        "outputId": "7b6eff9c-f974-44fb-97b6-6229ab80dd7a"
+        "id": "0MMrL3959hli"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Average latency original model: 0.0520 seconds\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "num_iters = 100\n",
         "\n",
@@ -449,21 +413,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "_IbAW0KA4Fm5",
-        "outputId": "20f734f6-2d96-4792-cb90-d45d1e77071e"
+        "id": "_IbAW0KA4Fm5"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Average latency optimized model: 0.0037 seconds\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Warmup\n",
         "for i in range(10):\n",

--- a/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
+++ b/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
@@ -127,7 +127,7 @@
       "source": [
         "In the following example we will try to optimize a standard resnet50 loaded directly from keras.\n",
         "\n",
-        "Speedster can accelerate neural networks without loss of a user-defined precision metric, e.g. accuracy, or can achieve faster acceleration by applying more aggressive optimization techniques, such as pruning and quantization, that may have a negative impact on the selectic metric. The maximum threshold value for accuracy loss is determined by the metric_drop_ths parameter. Read more in the [docs](https://nebuly.gitbook.io/nebuly/nebullvm/get-started).\n",
+        "Speedster can accelerate neural networks without loss of a user-defined precision metric, e.g. accuracy, or can achieve faster acceleration by applying more aggressive optimization techniques, such as pruning and quantization, that may have a negative impact on the selectic metric. The maximum threshold value for accuracy loss is determined by the metric_drop_ths parameter. Read more in the [docs](https://docs.nebuly.com/modules/speedster/getting-started).\n",
         "\n",
         "Let first test the optimization without accuracy loss (metric_drop_ths=0, default value), and then apply further accelerate it under the constrained of losing up to 2% of accuracy (metric = \"accuracy\", metric_drop_ths = 0.02)."
       ]

--- a/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
+++ b/notebooks/speedster/tensorflow/Accelerate_Tensorflow_ResNet50_with_Speedster.ipynb
@@ -11,7 +11,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "-KdJPm7M05Jc"
+      },
       "source": [
         "# Accelerate Tensorflow ResNet50 with Speedster"
       ]
@@ -56,7 +58,6 @@
     },
     {
       "cell_type": "markdown",
-      "id": "48aljCHu14-H",
       "metadata": {
         "id": "48aljCHu14-H"
       },
@@ -67,7 +68,6 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "QFQh3BVr1-GO",
       "metadata": {
         "id": "QFQh3BVr1-GO"
       },
@@ -78,7 +78,6 @@
     },
     {
       "cell_type": "markdown",
-      "id": "8a7a86b3",
       "metadata": {
         "id": "8a7a86b3"
       },
@@ -89,14 +88,27 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "cffbfa32",
       "metadata": {
         "id": "cffbfa32"
       },
       "outputs": [],
       "source": [
-        "!python -m nebullvm.installers.auto_installer  --backends tensorflow-full --compilers all"
+        "!python -m nebullvm.installers.auto_installer --backends tensorflow-full --compilers all"
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# This cell will fix version compatibility errors\n",
+        "!pip install virtualenv\n",
+        "!virtualenv -p python3 newenv\n",
+        "!pip install protobuf==3.12.2 speedster onnx==1.8.0"
+      ],
+      "metadata": {
+        "id": "l4gJ7VLVnTld"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -115,7 +127,7 @@
       "source": [
         "In the following example we will try to optimize a standard resnet50 loaded directly from keras.\n",
         "\n",
-        "Speedster can accelerate neural networks without loss of a user-defined precision metric, e.g. accuracy, or can achieve faster acceleration by applying more aggressive optimization techniques, such as pruning and quantization, that may have a negative impact on the selectic metric. The maximum threshold value for accuracy loss is determined by the metric_drop_ths parameter. Read more in the [docs](https://docs.nebuly.com/modules/speedster/getting-started).\n",
+        "Speedster can accelerate neural networks without loss of a user-defined precision metric, e.g. accuracy, or can achieve faster acceleration by applying more aggressive optimization techniques, such as pruning and quantization, that may have a negative impact on the selectic metric. The maximum threshold value for accuracy loss is determined by the metric_drop_ths parameter. Read more in the [docs](https://nebuly.gitbook.io/nebuly/nebullvm/get-started).\n",
         "\n",
         "Let first test the optimization without accuracy loss (metric_drop_ths=0, default value), and then apply further accelerate it under the constrained of losing up to 2% of accuracy (metric = \"accuracy\", metric_drop_ths = 0.02)."
       ]
@@ -142,14 +154,11 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "2RbgGruAeQcf",
-        "outputId": "9059699e-8177-4238-feec-7b6985338f7a"
+        "id": "2RbgGruAeQcf"
       },
       "outputs": [],
       "source": [
+        "# If you encountered any error, relaunch the cell\n",
         "import tensorflow as tf\n",
         "from tensorflow.keras.applications.resnet50 import ResNet50\n",
         "from speedster import optimize_model\n",
@@ -184,11 +193,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "cVMn6erJLQuu",
-        "outputId": "74c2b018-9e5a-4436-86df-19f82a5aa1fe"
+        "id": "cVMn6erJLQuu"
       },
       "outputs": [],
       "source": [
@@ -226,11 +231,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "MjGtKkeZSOc7",
-        "outputId": "03a683b7-d9cf-4551-bf2c-c3fc8fa7f552"
+        "id": "MjGtKkeZSOc7"
       },
       "outputs": [],
       "source": [
@@ -241,11 +242,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "dhe94Tk3SSfn",
-        "outputId": "b6044c5f-4281-47aa-b823-59d6f72c3fc9"
+        "id": "dhe94Tk3SSfn"
       },
       "outputs": [],
       "source": [
@@ -282,7 +279,15 @@
         "id": "dkt67_Orwlv4",
         "outputId": "2115dc49-9fe0-4e2c-c200-20868c6f50e8"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Average latency original model: 0.0524 seconds\n"
+          ]
+        }
+      ],
       "source": [
         "num_iters = 100\n",
         "\n",
@@ -318,7 +323,15 @@
         "id": "4PodpaDVfwzT",
         "outputId": "805344a8-90eb-4818-8363-d79012c02dd1"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Average latency optimized model: 0.0071 seconds\n"
+          ]
+        }
+      ],
       "source": [
         "# Warmup\n",
         "for i in range(10):\n",
@@ -354,11 +367,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "fO1nGqpj3p7z",
-        "outputId": "23f520d4-d06a-4058-e924-953aaa901385"
+        "id": "fO1nGqpj3p7z"
       },
       "outputs": [],
       "source": [
@@ -403,7 +412,15 @@
         "id": "0MMrL3959hli",
         "outputId": "7b6eff9c-f974-44fb-97b6-6229ab80dd7a"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Average latency original model: 0.0520 seconds\n"
+          ]
+        }
+      ],
       "source": [
         "num_iters = 100\n",
         "\n",
@@ -438,7 +455,15 @@
         "id": "_IbAW0KA4Fm5",
         "outputId": "20f734f6-2d96-4792-cb90-d45d1e77071e"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Average latency optimized model: 0.0037 seconds\n"
+          ]
+        }
+      ],
       "source": [
         "# Warmup\n",
         "for i in range(10):\n",
@@ -453,55 +478,108 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
-      "id": "ceb60d8c",
-      "metadata": {
-        "id": "ceb60d8c"
-      },
       "source": [
         "## Save and reload the optimized model"
-      ]
+      ],
+      "metadata": {
+        "id": "4XFMC1S6zXTU"
+      }
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
-      "id": "d9eda1a0",
-      "metadata": {},
       "source": [
         "We can easily save to disk the optimized model with the following line:"
-      ]
+      ],
+      "metadata": {
+        "id": "OXHVr3EAzbT5"
+      }
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "62b6fcbf",
-      "metadata": {},
-      "outputs": [],
       "source": [
         "optimized_model.save(\"model_save_path\")"
-      ]
+      ],
+      "metadata": {
+        "id": "3M565P-zzaFB"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
-      "id": "3c968d51",
-      "metadata": {},
       "source": [
-        "We can then load again the model:"
-      ]
+        "We can then load again the model:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "ee8CS_Evzg1j"
+      }
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "c1340c49",
-      "metadata": {},
-      "outputs": [],
       "source": [
         "from nebullvm.operations.inference_learners.base import LearnerMetadata\n",
         "\n",
         "optimized_model = LearnerMetadata.read(\"model_save_path\").load_model(\"model_save_path\")"
-      ]
+      ],
+      "metadata": {
+        "id": "zOQ88SY_zg-A"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Save and reload the optimized model"
+      ],
+      "metadata": {
+        "id": "GzDQNhMO1Cxn"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can easily save to disk the optimized model with the following line:"
+      ],
+      "metadata": {
+        "id": "JGqHm6FC1Cxo"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "optimized_model.save(\"model_save_path\")"
+      ],
+      "metadata": {
+        "id": "EovNfO451Cxo"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can then load again the model:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "hU0lv_121Cxo"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from nebullvm.operations.inference_learners.base import LearnerMetadata\n",
+        "\n",
+        "optimized_model = LearnerMetadata.read(\"model_save_path\").load_model(\"model_save_path\")"
+      ],
+      "metadata": {
+        "id": "xQBMMK5b1Cxo"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -525,7 +603,6 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
       "provenance": []
     },
     "gpuClass": "standard",
@@ -544,7 +621,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.9"
+      "version": "3.8.10"
     },
     "vscode": {
       "interpreter": {


### PR DESCRIPTION
when I wanted to run the cell containing `from speedster import optimize_model` on Google Colab this was the error that I got:  

`ContextualVersionConflict: (protobuf 3.19.6 (/usr/local/lib/python3.8/dist-packages), Requirement.parse('protobuf<4,>=3.20.2'), {'onnx'})`  

so I added this cell to the notebook and the problem was fixed:
```
!pip install virtualenv
!virtualenv -p python3 newenv   
!pip install protobuf==3.12.2 speedster onnx==1.8.0
```