### PR TITLE
Fix torchscript fp16 on int inputs

### DIFF
--- a/nebullvm/operations/optimizations/compilers/pytorch.py
+++ b/nebullvm/operations/optimizations/compilers/pytorch.py
@@ -89,7 +89,10 @@ class PytorchBackendCompiler(Compiler):
         input_sample = input_data.get_list(1)[0]
         if self.device is Device.GPU:
             if quantization_type is QuantizationType.HALF:
-                input_sample = [t.cuda().half() for t in input_sample]
+                input_sample = [
+                    t.cuda().half() if torch.is_floating_point(t) else t.cuda()
+                    for t in input_sample
+                ]
             else:
                 input_sample = [t.cuda() for t in input_sample]
 


### PR DESCRIPTION
use .half() only when input is float

Fixes #163 