### PR TITLE
add plotly to chatllama/setup.py

### DIFF
--- a/apps/accelerate/chatllama/setup.py
+++ b/apps/accelerate/chatllama/setup.py
@@ -13,6 +13,7 @@ REQUIREMENTS = [
     "transformers",
     "datasets",
     "openai",
+    "plotly",
 ]
 
 this_directory = Path(__file__).parent


### PR DESCRIPTION
chatllama/rlhf/utils.py::TrainingStats uses graph_objects from plotly but plotly is missing in requirements.

This adds plotly to chatllama/setup.py