### PR TITLE
[Chatllama] fix typo of discounted_rewards in PPO loss

### DIFF
--- a/apps/accelerate/chatllama/chatllama/rlhf/trainer.py
+++ b/apps/accelerate/chatllama/chatllama/rlhf/trainer.py
@@ -882,8 +882,8 @@ class RLTrainer:
                     # compute discounted rewards as in TRL
                     gamma = 0.5
                     discounted_rewards = torch.zeros_like(old_values)
-                    for i in range(discounted_rewards.shape[0]):
-                        for j in range(i, discounted_rewards.shape[0]):
+                    for i in range(discounted_rewards.shape[1]):
+                        for j in range(i, discounted_rewards.shape[1]):
                             discounted_rewards[:, i] += (
                                 gamma ** (j - i) * rewards[:, j]
                             )


### PR DESCRIPTION
# Issue
**discounted_rewards.shape[0]** means **batch_size**, so it cannot properly calculate discounted_rewards.
https://github.com/nebuly-ai/nebullvm/blob/8ccfadb00fa88bf0db6c605029a34bc6a1349655/apps/accelerate/chatllama/chatllama/rlhf/trainer.py#L880-L889

# Solve
To fix this, I've changed to use **discounted_rewards.shape[1]** instead of discounted_rewards.shape[0].

Closes #290 