### PR TITLE
[Nebullvm] Add Generator and FloatTensor classes to torch optional modules

### DIFF
--- a/nebullvm/optional_modules/torch.py
+++ b/nebullvm/optional_modules/torch.py
@@ -42,3 +42,5 @@ except ImportError:
     symbolic_trace = None
     QuantStub = DeQuantStub = DummyClass
     default_dynamic_qconfig = prepare_fx = convert_fx = None
+    Generator = DummyClass
+    FloatTensor = DummyClass


### PR DESCRIPTION
Add Generator and FloatTensor classes to torch optional modules so that it is possible to import module `nebullvm.tools.diffusers.py` even if torch is not installed