### PR TITLE
[ChatLLaMA] DocFix - RL training command in README.md missing filename

### DIFF
--- a/apps/accelerate/chatllama/README.md
+++ b/apps/accelerate/chatllama/README.md
@@ -114,8 +114,7 @@ You can train the 3 models in separate steps:
 - Training the Actor with reinforcement learning.
 
     ```bash
-    python artifacts/
-    artifacts/config/config.yaml --type RL
+    python artifacts/main.py artifacts/config/config.yaml --type RL
     ```
 
 


### PR DESCRIPTION
RL command in main readme file - https://github.com/nebuly-ai/nebullvm/blob/main/apps/accelerate/chatllama/README.md missing filename `main.py`

```
    python artifacts/
    artifacts/config/config.yaml --type RL
```

to

```
python artifacts/main.py artifacts/config/config.yaml --type RL
```