### PR TITLE
[ChatLLaMA] RL Trainer - is_deepspeed_init variable initialization

### DIFF
--- a/apps/accelerate/chatllama/chatllama/rlhf/trainer.py
+++ b/apps/accelerate/chatllama/chatllama/rlhf/trainer.py
@@ -555,6 +555,7 @@ class RLTrainer:
         # deepspeed initialization
         self.actor_model_engine = None
         self.critic_model_engine = None
+        self.is_deepspeed_init = None
 
         if self.config.actor.deepspeed_enable or self.config.critic.deepspeed_enable:
             deepspeed.init_distributed("nccl")


### PR DESCRIPTION
The variable `self.is_deepspeed_init` is initialized only if deepspeed is enabled in the actor or critic - [line](https://github.com/nebuly-ai/nebullvm/blob/87c6d132a37deea52aacb5e90324e74742970739/apps/accelerate/chatllama/chatllama/rlhf/trainer.py#L561)

In my case, i trained both actor and reward without enabling Deepspeed. Hence, the while training the RL model, i received error on this [line](https://github.com/nebuly-ai/nebullvm/blob/87c6d132a37deea52aacb5e90324e74742970739/apps/accelerate/chatllama/chatllama/rlhf/trainer.py#L773).

Initializing the variable to `None` solves the problem.