### PR TITLE
[ChatLLaMA] Reward Dataset Score Calculation

### DIFF
--- a/apps/accelerate/chatllama/chatllama/rlhf/reward.py
+++ b/apps/accelerate/chatllama/chatllama/rlhf/reward.py
@@ -223,7 +223,11 @@ class RewardDataset(Dataset):
     def __getitem__(self, idx: int):
         user_input = self.data[idx]["user_input"]
         completion = self.data[idx]["completion"]
-        score = float(self.data[idx]["score"])
+        if self.data[idx]["score"]:
+            score = float(self.data[idx]["score"])
+        else:
+            score = 2.5
+
         item = (user_input + completion, score)
         return item
 


### PR DESCRIPTION
While training the reward model using the dataset given in the README instructions, i observed that , some of the scores are getting passed to `RewardDataset` as `None`

Due to this, the training fails while converting the score to float - [line](https://github.com/nebuly-ai/nebullvm/blob/87c6d132a37deea52aacb5e90324e74742970739/apps/accelerate/chatllama/chatllama/rlhf/reward.py#L226)

Should we set the score to number  ( 0 or 2.5 ) or should we raise an error that the score should be between 0 and 5. @PierpaoloSorbellini @diegofiori  Need your inputs on the same
